### PR TITLE
Clear the transposition table before searching

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -161,6 +161,8 @@ fn iterative_deepening(refs: &mut SearchRefs) -> (Move, Option<SearchTerminate>)
         refs.search_state.allocated_time = time_slice.to_std().unwrap_or_default();
     }
 
+    refs.transposition_table.clear();
+
     refs.search_state.start_time = Some(Instant::now());
 
     while depth <= 128 && !stop {


### PR DESCRIPTION
 Fixes #3 (hopefully)

This should prevent all sorts of weird bugs from happening. It also replicates the behaviour of stockfish. Unfortunately this does mean that successive searches during a real game are slower. But fixing bugs is more important, and performance can be gained back from other things :)