### PR TITLE
Better PVS Implementation

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -362,8 +362,6 @@ fn negamax(
 
     let is_game_over = moves.is_empty();
 
-    let mut do_pvs = false;
-
     let mut hash_flag = Flag::Alpha;
     let mut best_move = None;
     let mut best_score = -EVAL_INFINITY - 1;
@@ -401,7 +399,7 @@ fn negamax(
         };
 
         if !is_draw(refs) {
-            if do_pvs {
+            if move_idx != 0 {
                 eval_score = -negamax(
                     refs,
                     &mut node_pv,
@@ -420,7 +418,7 @@ fn negamax(
                         -beta,
                         -alpha,
                         nmp_allowed,
-                        child_node_type,
+                        NodeType::Pv,
                     );
                 }
             } else {
@@ -483,8 +481,6 @@ fn negamax(
             alpha = eval_score;
 
             hash_flag = Flag::Exact;
-
-            do_pvs = true;
 
             pv.clear();
             pv.push(legal);

--- a/src/search.rs
+++ b/src/search.rs
@@ -392,12 +392,6 @@ fn negamax(
             0
         };
 
-        let child_node_type = if move_idx == 0 {
-            NodeType::Pv
-        } else {
-            NodeType::Other
-        };
-
         if !is_draw(refs) {
             if move_idx != 0 {
                 eval_score = -negamax(
@@ -407,7 +401,7 @@ fn negamax(
                     -alpha - 1,
                     -alpha,
                     nmp_allowed,
-                    child_node_type,
+                    NodeType::Other,
                 );
 
                 if eval_score > alpha {
@@ -418,7 +412,7 @@ fn negamax(
                         -beta,
                         -alpha,
                         nmp_allowed,
-                        NodeType::Pv,
+                        node_type,
                     );
                 }
             } else {
@@ -429,7 +423,7 @@ fn negamax(
                     -beta,
                     -alpha,
                     nmp_allowed,
-                    child_node_type,
+                    NodeType::Pv,
                 );
             }
         }


### PR DESCRIPTION
Fixes two flaws:

- It's better for PVS to be done on every move after the first move
- On a PV node, PVS re-search should be done as a PV node.

No SPRT testing is done due to #10, but it does bring dramatic improvement in time to depth.