### PR TITLE
Remove Null Move Pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -320,36 +320,6 @@ fn negamax(
         }
     }
 
-    if nmp_allowed && !is_check {
-        let r = if depth >= 6 { 4 } else { 3 };
-
-        if let Some(null_move_board) = refs.board.null_move() {
-            let old_pos = refs.board.clone();
-
-            *refs.board = null_move_board;
-
-            let eval = -negamax(
-                refs,
-                pv,
-                depth.saturating_sub(r).saturating_sub(1),
-                -beta,
-                -beta + 1,
-                false,
-                NodeType::Other,
-            );
-
-            *refs.board = old_pos;
-
-            if eval >= beta {
-                depth = depth.saturating_sub(r);
-
-                if depth == 0 {
-                    return quiescence(refs, pv, alpha, beta);
-                }
-            }
-        }
-    }
-
     let mut moves: ArrayVec<cozy_chess::Move, MAX_MOVES> = generate_moves(refs.board, false);
 
     order_moves(refs, &mut moves, tt_move);


### PR DESCRIPTION
This implementation of NMP seems incorrect. For starters when`eval >= beta` one should return a fail high instead of reducing. Additionally, there are certain conditions where nmp should not be done. [1] In the future, please make sure to test search modifications using SPRT [2] to make sure no regression is accidentally introduced.

Feel free to ask on [Stockfish Discord](https://discord.com/invite/GWDRS3kU6R) if you have any questions :)

[1] Refer to https://github.com/aronpetko/integral/blob/1d123ce3a1ec7e66c5ca67570e93f3e4ffbb6c6e/src/engine/search/search.cc#L352-L356.
[2] SPRT: https://rustic-chess.org/progress/sprt_testing.html

```
Results of eccat-new vs eccat-base (5+0.5, 1t, 16MB, 8moves_v3.pgn):
Elo: 7.31 +/- 5.85, nElo: 9.82 +/- 7.86
LOS: 99.29 %, DrawRatio: 35.04 %, PairsRatio: 1.09
Games: 7506, Wins: 2244, Losses: 2086, Draws: 3176, Points: 3832.0 (51.05 %)
Ptnml(0-2): [259, 910, 1315, 952, 317]
LLR: 3.00 (-2.94, 2.94) [0.00, 10.00]
```